### PR TITLE
unicode的str表示需要先转成Unicode才能再转成utf-8

### DIFF
--- a/pyssdb.py
+++ b/pyssdb.py
@@ -89,6 +89,8 @@ class Connection(object):
 
         st, ret = ret[0], ret[1:]
 
+        if cmd == 'info':
+            return ret[1]
         if st == 'not_found':
             return None
         elif st == 'ok':

--- a/pyssdb.py
+++ b/pyssdb.py
@@ -177,8 +177,10 @@ class Client(object):
         try:
             new_args = []
             for arg in args:
-                if isinstance(arg, str) or isinstance(arg, unicode):
+                if isinstance(arg, unicode):
                     new_args.append(arg.encode('utf-8'))
+                elif isinstance(arg, str):
+                    new_args.append(unicode(arg, 'utf-8').encode('utf-8'))
                 else:
                     new_args.append(arg)
             connection.send(cmd, *new_args)


### PR DESCRIPTION
例如一个key 为'\xe4\xb8\xad\xe5\x9b\xbd',它的type是str，但是这里没法直接encode('utf-8')会报错，需要先转化为unicode(也就是u'\u4e2d\u56fd'）再encode为utf-8。  要么unicode(arg, 'utf-8').encode('utf-8')要么arg.decode('utf-8').encode('utf-8')

不好意思，改了N次了，也都是刚遇到的情况。